### PR TITLE
More diagnostics logging, async protontricks setup, option to force Flatpak, point A;C Proton download to CoZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This Bash script is intended to automate the process of installing CoZ Steam pat
 
 **The instructions below are written specifically for the Steam Deck** as this has proven to be the most common use case. They should be largely adaptable to any desktop Linux installation, but for more general instructions, system requirements, and other information about the script including the CLI mode, see [GENERAL-INFO.md](/docs/GENERAL-INFO.md).
 
+See [TROUBLESHOOTING.md](/docs/TROUBLESHOOTING.md) if anything goes wrong during usage.
+
 ## Setup
 
 1. Switch to [Desktop Mode](https://youtu.be/FAf2s99-iik).
@@ -54,4 +56,4 @@ Worry not! See [TROUBLESHOOTING.md](/docs/TROUBLESHOOTING.md) for a list of comm
 
 ------------
 
-The Polyversal Linux Steam Patcher for the Committee of Zero's Science Adventure Steam Patches on Linux has been tested on Arch Linux, Fedora 37, and SteamOS 3.x. Any pull requests or feedback related to other distribtions are especially appreciated.
+The Polyversal Linux Steam Patcher for the Committee of Zero's Science Adventure Steam Patches on Linux has been tested on Arch Linux, Fedora 37, and SteamOS 3.x. Any pull requests or feedback related to other distributions are especially appreciated.

--- a/docs/AC.md
+++ b/docs/AC.md
@@ -20,4 +20,6 @@ The Polyversal Patcher makes it easy to install this Proton version:
 
 And that's it! You can [return to the instructions](/README.md#setup) and pick up where you left off.
 
-For troubleshooting, see the aptly-named [TROUBLESHOOTING.md](/docs/TROUBLESHOOTING.md).
+If for some reason the script is unable to successfully install the custom Proton, you can [directly download it here](https://github.com/CommitteeOfZero/ProtonGE-AC/releases/download/1.0.0/protonge-anonymouscode.tar.gz) and [install it manually](https://github.com/GloriousEggroll/proton-ge-custom#installation).
+
+For all other troubleshooting, see the aptly-named [TROUBLESHOOTING.md](/docs/TROUBLESHOOTING.md).

--- a/docs/GAMES.md
+++ b/docs/GAMES.md
@@ -10,7 +10,7 @@ Below is a table with relevant information for each game that currently has a pa
 | CHAOS;CHILD           |        8                    |       cc       | 970570     |
 | STEINS;GATE 0         |        8                    |      sg0       | 825630     |
 | ROBOTICS;NOTES DaSH   |        7[^rn]               |      rnd       | 1111390    |
-| ANONYMOUS;CODE        |  [Custom Proton-GE build](http://sonome.dareno.me/projects/coz-linux-deck.html)     |      ac        | 2291020    |
+| ANONYMOUS;CODE        |  [Custom Proton-GE build](https://github.com/CommitteeOfZero/ProtonGE-AC/releases)     |      ac        | 2291020    |
 
 Using Proton Experimental may or may not work for any given game; be sure to try it with the required version given here before troubleshooting further.
 

--- a/docs/GENERAL-INFO.md
+++ b/docs/GENERAL-INFO.md
@@ -137,6 +137,9 @@ The following options are available when invoking the script from the terminal.
 - `-r | --steamroot NEW_ROOT`
   - Use `NEW_ROOT` as the root of your steam install instead of `~/.steam/root`.
   - This likely has limited use cases, though it may help if you have Flatpak Steam installed and the root is in `/var/app/...`. Do note that Flatpak Steam has not been tested at the time of writing.
+- `-F | --force-flatpak`
+  - Use Flatpak Protontricks even if there exists a system install.
+  - Very useful for development, but also nice if your package manager doesn't yet have the latest version in its repos. Or if you just feel like it.
 
 ## Notes
 

--- a/docs/VERIFY.md
+++ b/docs/VERIFY.md
@@ -2,7 +2,7 @@
 
 Below you can find a list of the quickest ways to verify that the installation of each game's CoZ patch was successful.
 
-Regardless of the specific game, do make sure upon launching from Steam that you are met with the black CoZ game launcher and not the vanilla (uglier) beige launcher.
+Regardless of the specific game, do make sure upon launching from Steam that you are met with the black CoZ game launcher and not the (uglier) beige vanilla launcher.
 
 As always, check [TROUBLESHOOTING.md](/docs/TROUBLESHOOTING.md) if it turns out that your game has in fact not been patched correctly.
 

--- a/polyversal
+++ b/polyversal
@@ -35,7 +35,7 @@ readonly AC_PROTON_DIRNAME='protonge-anonymouscode'
 function print_usage() {
   cat << EOF >&2
 usage: polyversal [ -v | --verbose ] [ -h | --help ] [ --log ]
-                  [ -r | --steamroot ] ...
+                  [ -r | --steamroot ] [ -F | --force-flatpak ] ...
 
 Use a GUI for selecting everything graphically.
 $ $progname
@@ -69,6 +69,8 @@ options:
                             default when running from the desktop file
   -r, --steamroot NEW_ROOT  Use NEW_ROOT as Steam's root directory instead of
                             ~/.local/share/Steam
+  -F, --force-flatpak       Force the use of Flatpak Protontricks even if a
+                            system install is detected.
 
 EOF
 }

--- a/polyversal
+++ b/polyversal
@@ -19,7 +19,7 @@ exectime=$(iso_date)
 readonly exectime
 
 # For checking whether the script is out-of-date
-readonly VERSION=2.0.0
+readonly VERSION=2.1.0
 readonly REPO_ID="CommitteeOfZero/polyversal-coz-linux-patcher"
 readonly URL_RELEASES="https://github.com/${REPO_ID}/releases"
 readonly URL_API_LATEST="https://api.github.com/repos/${REPO_ID}/releases/latest"

--- a/polyversal
+++ b/polyversal
@@ -8,10 +8,9 @@ readonly progname
 DATADIR=$(dirname "$0")
 readonly DATADIR
 
-# Protontricks 1.10.1 or later is needed because anything earlier gives a
-# cryptic message about magic numbers.
+# Protontricks versions earlier than this minversion will cause issues that are hard to make sense of.
 readonly ptx_flatpak='com.github.Matoking.protontricks'
-readonly ptx_minversion='1.10.1'
+readonly ptx_minversion=1.11.0
 
 # For log files and the like, all hail ISO 8601.
 # People likely won't be running this more than once in a second.
@@ -174,7 +173,10 @@ function zenity_warn() {
 # 'fp' = Flatpak, 'sys' = system install
 # Other arguments don't do anything. Don't use them!
 # is_ptxvalid <fp|sys>
-function is_ptxvalid() {
+function check_ptx() {
+
+  # usage: check_ptx <fp|sys>
+
   local ptx_cmd
   case $1 in
     fp)
@@ -186,18 +188,20 @@ function is_ptxvalid() {
   # Decent way to check it's actually functional.
   local cur_ver
   ! cur_ver=$($ptx_cmd --version) && return 1
+  log_info "protontricks version output: '$cur_ver'"
 
   local older_ver
   older_ver=$(printf '%s\n%s\n' "protontricks ($ptx_minversion)" "$cur_ver" | sort -V | head -n 1)
 
+  # really only useful for system protontricks bc we'll always update flatpak
   [[ $older_ver == "protontricks ($ptx_minversion)" ]]
 }
 
 
 ### Option Parsing ###
 
-longopts='help,verbose,log,steamroot:,i-really-want-to-run-this-as-root-dont-question-me-boy'
-if ! parsed_args=$(getopt -n "$progname" -o 'hvr:' --long "$longopts" -- "$@"); then
+longopts='help,verbose,log,steamroot:,force-flatpak,i-really-want-to-run-this-as-root-dont-question-me-boy'
+if ! parsed_args=$(getopt -n "$progname" -o 'hvr:F' --long "$longopts" -- "$@"); then
   log_fatal "error parsing command line arguments"
   print_usage
   exit 1
@@ -207,6 +211,7 @@ eval set -- "$parsed_args"
 mode_debug=false
 mode_filelog=false
 STEAMROOT=$HOME/.steam/root
+FORCE_FLATPAK=false
 allow_root=false
 while true; do
   case "$1" in
@@ -222,6 +227,9 @@ while true; do
     -r | --steamroot)
       STEAMROOT=$2
       shift 2 ;;
+    -F | --force-flatpak)
+      FORCE_FLATPAK=true
+      shift ;;
     --i-really-want-to-run-this-as-root-dont-question-me-boy)
       allow_root=true
       shift ;;
@@ -283,8 +291,6 @@ log_info "Hardware: ${mobo_vendor:-[could not detect mobo vendor]} ${mobo_name:-
 log_info "Starting Polyversal Patcher on $(date) ..."
 
 
-### Protontricks Setup ###
-
 # Detect whether the machine is a Steam Deck.
 is_deck=false
 if grep -qE '^VERSION_CODENAME=holo' /etc/os-release; then
@@ -292,55 +298,79 @@ if grep -qE '^VERSION_CODENAME=holo' /etc/os-release; then
   log_info "detected Steam Deck environment ..."
 fi
 
+
+### Functionality Functions ###
+
 # We need Protontricks either through a system install or through Flatpak to
 # work the magic. Prefer system install since it plays nice with relative dirs
 # and doesn't need permissions to be setup, but if it's unavailable or outdated
 # then use Flatpak.
-ptx_cmd='protontricks'
+ptx_cmd=
 is_flatpak=false
-if is_cmd protontricks && is_ptxvalid sys; then
-  log_info "detected valid system install of protontricks ..."
-else
-  if is_cmd protontricks; then
-    log_warn "system install of protontricks has insufficient version: $(protontricks --version) < $ptx_minversion"
+ptx_pid=  # this will be run in a subshell on script start so the actual GUI starts right away
+function setup_protontricks() {
+
+  # usage: setup_protontricks
+
+  local ret_code=0
+
+  # check for valid system install
+  if ! $FORCE_FLATPAK; then
+    if is_cmd protontricks; then
+      if check_ptx sys; then
+        log_info "detected valid system install of protontricks"
+
+        # because i'm funny.
+        # (but more precisely because we only ever send this function to the background, and subshells can't modify
+        # global variables like $ptx_cmd belonging to the parent shell, so we set it based on the return code instead.)
+        # now LAUGH
+        return 69
+      else
+        log_warn "system install of protontricks failed basic version check. defaulting to flatpak"
+      fi
+    else
+      log_info "system install of protontricks not found"
+    fi
   else
-    log_info "system install of protontricks not found"
-  fi
+    log_info "forcing Flatpak protontricks"
+  fi  # ififif fififi, no bad code smell here for me
 
   log_info "proceeding with flatpak ..."
 
   # Nothing doing if no flatpak :(
   if ! is_cmd flatpak; then
-    log_fatal "either flatpak nor valid system install of protontricks was detected"
-    zenity_error "Neither Flatpak nor system Protontricks >= $ptx_minversion was found. Please install one of the two and then try again."
-    exit 1
+    log_fatal "neither flatpak nor valid system install of protontricks was detected"
+    return 1
   fi
 
   # Install protontricks if it's not already
-  if ! flatpak list | grep -q "$ptx_flatpak" -; then
+  local just_installed=false  # one would hope that a fresh install grabs the latest version
+  if ! flatpak list --system | grep -q "$ptx_flatpak" -; then
     log_warn "protontricks is not installed on flatpak. attempting installation ..."
-    if ! flatpak install -y "$ptx_flatpak"; then
+
+    # one would think this should be --user, but no. --system is the default and --user straight up doesn't find the
+    # package on some systems (read: mine)
+    if ! flatpak install --system -y "$ptx_flatpak"; then
       log_fatal "error occurred while installing flatpak protontricks"
-      zenity_error "An error occurred while installing Protontricks via Flatpak."
-      exit 1
+      return 2
     fi
+    just_installed=true
     log_info "flatpak protontricks installed successfully"
   fi
 
   # Just update no matter what, outdated versions beyond the minimum have alrady caused issues
-  if ! flatpak update -y "$ptx_flatpak"; then
+  if ! $just_installed && ! flatpak update --system -y "$ptx_flatpak"; then
     log_warn "error occurred while updating flatpak protontricks"
-    zenity_warn "An error occurred while updating Flatpak Protontricks. The script will continue, although this may or may not cause issues."
+    ret_code=43  # not dire enough to kill the function, or by extension the script
   else
     log_info "flatpak protontricks either updated successfully or was already up-to-date"
   fi
 
   is_flatpak=true
-  ptx_cmd="flatpak run $ptx_flatpak"
-fi
+  [[ $ret_code != 43 ]] && ret_code=42  # return codes only go up to 255 and i'm devastated
 
-
-### Functionality Functions ###
+  return $ret_code
+}
 
 # Get the target game and initialize the relevant variables
 appid=
@@ -430,6 +460,43 @@ function set_game() {
       exit 1
       ;;
   esac
+
+  # for all script verbs that use protontricks, THIS is the first place an actual protontricks command is used.
+  # so we wait here for setup_protontricks to complete if it hasn't yet.
+  wait $ptx_pid
+  local setup_ret=$?
+  log_debug "ptx setup returned $setup_ret"
+
+  # return codes for setup_protontricks are:
+  # 0 - should be impossible
+  # 1 - neither `flatpak` nor system ptx was found on the system
+  # 2 - something went wrong installing flatpak ptx
+  # 42 - use flatpak protontricks
+  # 43 - use flatpak, but something went wrong while updating
+  # 69 - use system protontricks
+  case $setup_ret in
+    0)
+      zenity_error "This window shouldn't appear; something has gone horribly wrong. Please open a GitHub issue saying you saw this if you have a minute."
+      log_error "reached the impossible retcode 0 from setup_protontricks, AAAAAAAAAA"
+      ;;
+    1)
+      zenity_error "Neither Flatpak nor system Protontricks >= $ptx_minversion was found. Please install one of the two and then try again."
+      exit 1 ;;
+    2)
+      zenity_error "An error occurred while installing Protontricks via Flatpak. Check the logs for details."
+      exit 2 ;;
+    42)
+      ptx_cmd="flatpak run $ptx_flatpak"
+      ;;
+    43)
+      ptx_cmd="flatpak run $ptx_flatpak"
+      zenity_warn "An error occurred while updating Flatpak Protontricks. The script will continue, but this may cause issues."
+      ;;  # no exit, just a warning
+    69)  # I SAID LAUGH
+      ptx_cmd='protontricks'
+      ;;
+  esac
+  log_debug "ptx setup subshell finished, ptx_cmd = '$ptx_cmd'"
 
   if ! gamedir=$($ptx_cmd -c 'pwd' $appid); then
     # protontricks outputs to stdout even in the case of an error, so $gamedir actually has the error message.
@@ -1033,6 +1100,10 @@ function start_screen() {
 }
 
 
-# Actually start the script
+## Actually start the script
+
+# send the setup to a subshell so that there's no delay in the GUI startup. now THAT'S ux. until it breaks. which it might
+setup_protontricks &
+ptx_pid=$!
 check_update &
 start_screen "$@"

--- a/polyversal
+++ b/polyversal
@@ -25,8 +25,7 @@ readonly URL_RELEASES="https://github.com/${REPO_ID}/releases"
 readonly URL_API_LATEST="https://api.github.com/repos/${REPO_ID}/releases/latest"
 
 # Custom Proton download
-readonly AC_PROTON_URL='https://hawkhe.art/protonge-anonymouscode.tar.gz'
-readonly AC_PROTON_MD5='1ab4a7d9d0351e0242436caf2964b73a'
+readonly AC_PROTON_URL='https://github.com/CommitteeOfZero/ProtonGE-AC/releases/download/1.0.0/protonge-anonymouscode.tar.gz'
 readonly AC_PROTON_DIRNAME='protonge-anonymouscode'
 
 
@@ -854,7 +853,7 @@ function download_ac_proton() {
 
   # CLI is so much easier jfc
   if ! $is_gui; then
-    if ! curl -o "$proton_tar_name" "$AC_PROTON_URL"; then
+    if ! curl -Lo "$proton_tar_name" "$AC_PROTON_URL"; then
       log_error "cURL error occurred while downloading custom proton"
       exit 1
     fi
@@ -869,7 +868,12 @@ function download_ac_proton() {
     exit 1
   fi
 
-  curl -o "$proton_tar_name" "$AC_PROTON_URL" > "$curl_fifo" 2>&1 &
+  if $mode_debug; then
+    # show cURL output for debugging
+    curl -Lo "$proton_tar_name" "$AC_PROTON_URL" 2>&1 | tee "$curl_fifo" 1>&2 &
+  else
+    curl -Lo "$proton_tar_name" "$AC_PROTON_URL" > "$curl_fifo" 2>&1 &
+  fi
   dl_proc=$!
 
   (

--- a/polyversal
+++ b/polyversal
@@ -253,14 +253,8 @@ fi
 
 set_logcolors   # after all the output redirection
 
-
-log_info "Starting Polyversal Patcher on $(date) ..."
-
-
-### set GUI/CLI mode ###
-
-# GUI mode: 0 args
-# CLI mode: 2 or 3 args
+# GUI mode: 0 positional args
+# CLI mode: >= 1 args
 is_gui=false
 if [[ $# -eq 0 ]]; then
   if ! is_cmd zenity; then
@@ -270,6 +264,23 @@ if [[ $# -eq 0 ]]; then
   fi
   is_gui=true
 fi
+
+
+# Get some basic info on the user's machine (distro, kernel, CPU/GPU if it works)
+os_pretty_name=$(grep -E ^PRETTY_NAME /etc/os-release)
+mobo_vendor=$(cat /sys/devices/virtual/dmi/id/board_vendor)
+mobo_name=$(cat /sys/devices/virtual/dmi/id/board_name)
+cpu_name=$(lscpu | sed -nE 's/Model name:[[:space:]]+(.+)/\1/p')
+vga_controller_name=$(lspci | sed -nE 's/^.*VGA compatible controller: (.+)/\1/p')
+weird_3d_name=$(lspci | sed -nE 's/^.*3D controller: (.+)/\1/p')  # some nvidia laptops do this for some reason
+gpu_output=$vga_controller_name
+[[ -n $weird_3d_name ]] && gpu_output="VGA compatible controller: $vga_controller_name ; 3D controller: $weird_3d_name"
+
+log_info "Machine info: $(uname -srmo) ${os_pretty_name:-[no pretty name found]}"
+log_info "Hardware: ${mobo_vendor:-[could not detect mobo vendor]} ${mobo_name:-[could not detect mobo name]} | ${cpu_name:-[could not detect CPU]} | ${gpu_output:-[could not detect GPU]}"
+
+
+log_info "Starting Polyversal Patcher on $(date) ..."
 
 
 ### Protontricks Setup ###


### PR DESCRIPTION
- output system information on script startup
  - distro, kernel version, mobo, CPU, GPU, etc

- set up Protontricks in the background and only await it once it's actually needed for setting the game directory
  - makes the starting screen more responsive on startup since it doesn't have to wait for `flatpak update` to complete
  - add `--system` option to all Flatpak calls since apparently not specifying it can break things
    - and `--user` isn't the default somehow?
  - minimum Protontricks version bumped to 1.11.0
    - who knows if that's necessary but 1.10.1 was breaking for one dude and that's enough

- add `-F | --force-flatpak` option to override detected system protontricks
  - idk why it took me so long to think of this, it would've made my life so much easier

- replace Hawk's domain link with the CoZ repo download for the A;C Proton build

- small wording edits in documentation

Tested on Arch Linux and Steam Deck (Bazzite, Fedora 39)