### PR TITLE
Zenity hotfix

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -83,6 +83,22 @@ Once the terminal is open, simply invoke it by typing the below command and hitt
 
 The launch window should then appear.
 
+If that still doesn't work, there's one more thing you can try: running the script via the CLI mode. This is far less prone to issues, but it lacks a graphical interface.
+
+Luckily, it's still very easy to do. In the terminal that you opened, paste or type the following but **don't** hit enter yet:
+
+```bash
+./polyversal install <GAME> 
+```
+
+Be sure to include the trailing space, and replace `<GAME>` with the [abbreviation of the game you want to patch](/docs/GAMES.md). For example, Robotics;Notes ELITE would be `./polyversal install rne `.
+
+Then, click and drag the CoZ patch folder from the file browser onto the terminal and hit Enter. Hopefully the script runs successfully at this point and you are met with the patch launcher.
+
+![A gif demonstrating how to run the script in CLI mode](/assets/gif/cli.gif "Fish is objectively the best shell, but I like zsh")
+
+For other script actions besides installing a patch, e.g. nuking a prefix or installing the A;C Proton build, see [the full docs on the CLI mode](/docs/GENERAL-INFO.md#cli).
+
 ## Nothing worked and everything is broken! HELP!
 
 First of all, calm down. Yelling isn't going to get us anywhere.

--- a/polyversal
+++ b/polyversal
@@ -2,6 +2,10 @@
 
 ### Constants ###
 
+# Script version, used to check if out-of-date.
+# Update this when creating a new release.
+readonly VERSION=2.1.1
+
 progname="$(basename "$0")"
 readonly progname
 
@@ -18,8 +22,7 @@ function iso_date() { date +%Y%m%dT%H%M%S; }
 exectime=$(iso_date)
 readonly exectime
 
-# For checking whether the script is out-of-date
-readonly VERSION=2.1.0
+# Repo info for version check
 readonly REPO_ID="CommitteeOfZero/polyversal-coz-linux-patcher"
 readonly URL_RELEASES="https://github.com/${REPO_ID}/releases"
 readonly URL_API_LATEST="https://api.github.com/repos/${REPO_ID}/releases/latest"

--- a/polyversal
+++ b/polyversal
@@ -157,7 +157,7 @@ function is_cmd() {
 # Shadows any call to zenity so we don't accidentally forget an $is_gui
 function zenity() {
   ! $is_gui && return 0
-  command zenity --icon="${DATADIR}/assets/logo-square.svg" "$@"
+  command zenity "$@"
 }
 
 # Happens often enough to warrant a function


### PR DESCRIPTION
The `--window-icon` argument is deprecated on newer Zenity versions, but the newly-supported `--icon` argument is absent on older versions and has caused at least two people's script invocations to fail. Presented with this Catch-22, I just scrapped the thing altogether. I'm p sure the icon doesn't even show up that much after the new Zenity GUI overhaul, whenever they did that.

- removed `--icon` parameter to zenity calls
- documented how to run the script in CLI mode, which is how we solved those two issues on Discord
  - useful as a last resort if the GUI really feels like failing